### PR TITLE
Enhance threat system and add manual tank role management

### DIFF
--- a/ElvUI/Core/API.lua
+++ b/ElvUI/Core/API.lua
@@ -146,8 +146,11 @@ function E:CheckRole(event)
 	local talentTree = self:GetTalentSpecInfo()
 	local role
 	
-	-- First check manual tank assignment (always takes priority)
-	if self:GetAssignedTankRole("player") then
+	-- First check forceRole from /tankmode command
+	if self.db.general and self.db.general.forceRole then
+		role = self.db.general.forceRole
+	-- Then check manual tank assignment from right-click menu
+	elseif self:GetAssignedTankRole("player") then
 		role = "Tank"
 	-- Fall back to talent-based detection
 	elseif type(self.ClassRole[self.myclass]) == "string" then

--- a/ElvUI/Core/API.lua
+++ b/ElvUI/Core/API.lua
@@ -110,6 +110,10 @@ end
 
 -- Get assigned tank role for a specific unit
 function E:GetAssignedTankRole(unit)
+	if not self.db or not self.db.general then
+		return false
+	end
+	
 	if not self.db.general.tankAssignments then
 		self.db.general.tankAssignments = {}
 	end
@@ -123,6 +127,10 @@ end
 
 -- Set tank role for a specific unit
 function E:SetTankRole(unit, isTank)
+	if not self.db or not self.db.general then
+		return
+	end
+	
 	if not self.db.general.tankAssignments then
 		self.db.general.tankAssignments = {}
 	end
@@ -146,8 +154,8 @@ function E:CheckRole(event)
 	local talentTree = self:GetTalentSpecInfo()
 	local role
 	
-	-- First check forceRole from /tankmode command
-	if self.db.general and self.db.general.forceRole then
+	-- First check forceRole from /tankmode command (if db is initialized)
+	if self.db and self.db.general and self.db.general.forceRole then
 		role = self.db.general.forceRole
 	-- Then check manual tank assignment from right-click menu
 	elseif self:GetAssignedTankRole("player") then

--- a/ElvUI/Core/API.lua
+++ b/ElvUI/Core/API.lua
@@ -433,6 +433,11 @@ function E:PLAYER_ENTERING_WORLD()
 		self:UpdateMedia()
 		self.MediaUpdated = true
 	end
+	
+	-- Clear tank assignments from previous sessions
+	if self.db.general and self.db.general.tankAssignments then
+		wipe(self.db.general.tankAssignments)
+	end
 
 	local _, instanceType = IsInInstance()
 	if instanceType == "pvp" then

--- a/ElvUI/Core/Commands.lua
+++ b/ElvUI/Core/Commands.lua
@@ -35,27 +35,6 @@ function E:ToggleTankRole()
 	self:CheckRole()
 end
 
-function E:ListTanks()
-	if not self.db.general.tankAssignments or next(self.db.general.tankAssignments) == nil then
-		self:Print("No tanks assigned.")
-	else
-		self:Print("Assigned tanks:")
-		for name, _ in pairs(self.db.general.tankAssignments) do
-			self:Print("  - " .. name)
-		end
-	end
-end
-
-function E:ClearTanks()
-	if self.db.general.tankAssignments then
-		wipe(self.db.general.tankAssignments)
-		self:Print("Cleared all tank assignments.")
-		self:CheckRole()
-	else
-		self:Print("No tank assignments to clear.")
-	end
-end
-
 function E:Grid(msg)
 	msg = msg and tonumber(msg)
 	if type(msg) == "number" and (msg <= 256 and msg >= 4) then
@@ -318,8 +297,6 @@ function E:LoadCommands()
 	self:RegisterChatCommand("cleanguild", "MassGuildKick")
 	self:RegisterChatCommand("estatus", "ShowStatusReport")
 	self:RegisterChatCommand("tankmode", "ToggleTankRole") -- Toggle tank role for threat colors
-	self:RegisterChatCommand("tanklist", "ListTanks") -- List all assigned tanks
-	self:RegisterChatCommand("tankclear", "ClearTanks") -- Clear all tank assignments
 	-- self:RegisterChatCommand("aprilfools", "") --Don't need this until next april fools
 
 	if E.private.actionbar.enable then

--- a/ElvUI/Core/Commands.lua
+++ b/ElvUI/Core/Commands.lua
@@ -28,10 +28,10 @@ function E:ToggleTankRole()
 	
 	if self.db.general.forceRole == "Tank" then
 		self.db.general.forceRole = nil
-		self:Print("Tank role override DISABLED. Using automatic detection.")
+		self:Print("Tank role DISABLED.")
 	else
 		self.db.general.forceRole = "Tank"
-		self:Print("Tank role override ENABLED. You are now considered a tank for threat colors.")
+		self:Print("Tank role ENABLED.")
 	end
 	
 	-- Trigger role check to update immediately

--- a/ElvUI/Core/Commands.lua
+++ b/ElvUI/Core/Commands.lua
@@ -19,6 +19,22 @@ local GetNumAddOns = GetNumAddOns
 local GetCVarBool = GetCVarBool
 local ERR_NOT_IN_COMBAT = ERR_NOT_IN_COMBAT
 
+function E:ToggleTankRole()
+	-- Toggle between Tank and automatic detection
+	if not self.db.general then self.db.general = {} end
+	
+	if self.db.general.forceRole == "Tank" then
+		self.db.general.forceRole = nil
+		self:Print("Tank role override DISABLED. Using automatic detection.")
+	else
+		self.db.general.forceRole = "Tank"
+		self:Print("Tank role override ENABLED. You are now considered a tank for threat colors.")
+	end
+	
+	-- Trigger role check to update immediately
+	self:CheckRole()
+end
+
 function E:Grid(msg)
 	msg = msg and tonumber(msg)
 	if type(msg) == "number" and (msg <= 256 and msg >= 4) then
@@ -280,6 +296,7 @@ function E:LoadCommands()
 	self:RegisterChatCommand("farmmode", "FarmMode")
 	self:RegisterChatCommand("cleanguild", "MassGuildKick")
 	self:RegisterChatCommand("estatus", "ShowStatusReport")
+	self:RegisterChatCommand("tankmode", "ToggleTankRole") -- Toggle tank role for threat colors
 	-- self:RegisterChatCommand("aprilfools", "") --Don't need this until next april fools
 
 	if E.private.actionbar.enable then

--- a/ElvUI/Core/Commands.lua
+++ b/ElvUI/Core/Commands.lua
@@ -35,6 +35,27 @@ function E:ToggleTankRole()
 	self:CheckRole()
 end
 
+function E:ListTanks()
+	if not self.db.general.tankAssignments or next(self.db.general.tankAssignments) == nil then
+		self:Print("No tanks assigned.")
+	else
+		self:Print("Assigned tanks:")
+		for name, _ in pairs(self.db.general.tankAssignments) do
+			self:Print("  - " .. name)
+		end
+	end
+end
+
+function E:ClearTanks()
+	if self.db.general.tankAssignments then
+		wipe(self.db.general.tankAssignments)
+		self:Print("Cleared all tank assignments.")
+		self:CheckRole()
+	else
+		self:Print("No tank assignments to clear.")
+	end
+end
+
 function E:Grid(msg)
 	msg = msg and tonumber(msg)
 	if type(msg) == "number" and (msg <= 256 and msg >= 4) then
@@ -297,6 +318,8 @@ function E:LoadCommands()
 	self:RegisterChatCommand("cleanguild", "MassGuildKick")
 	self:RegisterChatCommand("estatus", "ShowStatusReport")
 	self:RegisterChatCommand("tankmode", "ToggleTankRole") -- Toggle tank role for threat colors
+	self:RegisterChatCommand("tanklist", "ListTanks") -- List all assigned tanks
+	self:RegisterChatCommand("tankclear", "ClearTanks") -- Clear all tank assignments
 	-- self:RegisterChatCommand("aprilfools", "") --Don't need this until next april fools
 
 	if E.private.actionbar.enable then

--- a/ElvUI/Core/Commands.lua
+++ b/ElvUI/Core/Commands.lua
@@ -21,7 +21,10 @@ local ERR_NOT_IN_COMBAT = ERR_NOT_IN_COMBAT
 
 function E:ToggleTankRole()
 	-- Toggle between Tank and automatic detection
-	if not self.db.general then self.db.general = {} end
+	if not self.db.general then 
+		self:Print("Error: Database not initialized. Please reload UI.")
+		return
+	end
 	
 	if self.db.general.forceRole == "Tank" then
 		self.db.general.forceRole = nil

--- a/ElvUI/Libraries/oUF/elements/threatindicator.lua
+++ b/ElvUI/Libraries/oUF/elements/threatindicator.lua
@@ -63,6 +63,23 @@ local function Update(self, event, unit)
 	local r, g, b
 	if(status and status > 0) then
 		r, g, b = GetThreatStatusColor(status)
+		
+		-- Invert colors for tanks in 3.3.5a where role system doesn't exist
+		-- For tanks: High threat (status 3) = good (green), Low threat = bad (red)
+		-- For DPS: High threat = bad (red), Low threat = good (green)
+		if _G.ElvUI then
+			local E = _G.ElvUI[1]
+			if E and E.Role == "Tank" then
+				-- Invert the colors for tanks
+				if status == 3 then -- tanking, should be green
+					r, g, b = 0, 1, 0
+				elseif status == 2 then -- high threat but not tanking, should be yellow
+					r, g, b = 1, 1, 0
+				elseif status == 1 then -- low threat, should be orange/red
+					r, g, b = 1, 0.5, 0
+				end
+			end
+		end
 
 		if(element.SetVertexColor) then
 			element:SetVertexColor(r, g, b)

--- a/ElvUI/Libraries/oUF/elements/threatindicator.lua
+++ b/ElvUI/Libraries/oUF/elements/threatindicator.lua
@@ -64,19 +64,34 @@ local function Update(self, event, unit)
 	if(status and status > 0) then
 		r, g, b = GetThreatStatusColor(status)
 		
-		-- Invert colors for tanks in 3.3.5a where role system doesn't exist
+		-- Invert colors ONLY for tank units, not for all units when viewed by a tank
 		-- For tanks: High threat (status 3) = good (green), Low threat = bad (red)
 		-- For DPS: High threat = bad (red), Low threat = good (green)
 		if _G.ElvUI then
 			local E = _G.ElvUI[1]
-			if E and E.Role == "Tank" then
-				-- Invert the colors for tanks
-				if status == 3 then -- tanking, should be green
-					r, g, b = 0, 1, 0
-				elseif status == 2 then -- high threat but not tanking, should be yellow
-					r, g, b = 1, 1, 0
-				elseif status == 1 then -- low threat, should be orange/red
-					r, g, b = 1, 0.5, 0
+			if E then
+				-- Check if THIS UNIT is a tank, not if the viewer is a tank
+				local unitName = UnitName(unit)
+				local unitIsTank = false
+				
+				-- Check if it's the player and they're in tank mode
+				if UnitIsUnit(unit, "player") then
+					unitIsTank = (E.db and E.db.general and E.db.general.forceRole == "Tank") or 
+					             (E.db and E.db.general and E.db.general.tankAssignments and E.db.general.tankAssignments[E.myname])
+				-- Check if this unit is in our tank assignments
+				elseif unitName and E.db and E.db.general and E.db.general.tankAssignments then
+					unitIsTank = E.db.general.tankAssignments[unitName] == true
+				end
+				
+				if unitIsTank then
+					-- Invert the colors for THIS tank unit
+					if status == 3 then -- tanking, should be green
+						r, g, b = 0, 1, 0
+					elseif status == 2 then -- high threat but not tanking, should be yellow
+						r, g, b = 1, 1, 0
+					elseif status == 1 then -- low threat, should be orange/red
+						r, g, b = 1, 0.5, 0
+					end
 				end
 			end
 		end

--- a/ElvUI/Modules/Nameplates/Elements/HealthBar.lua
+++ b/ElvUI/Modules/Nameplates/Elements/HealthBar.lua
@@ -35,8 +35,10 @@ function NP:Update_HealthColor(frame)
 		local isTank = E.Role == "Tank" or (E.GetAssignedTankRole and E:GetAssignedTankRole("player"))
 		
 		-- Check if another tank has this mob (for off-tank coloring)
+		-- Only relevant when in a group
 		local otherTankHasAggro = false
-		if isTank and status and status < 3 then -- We're a tank but don't have aggro
+		local inGroup = GetNumPartyMembers() > 0 or GetNumRaidMembers() > 0
+		if inGroup and isTank and status and status < 3 then -- We're a tank but don't have aggro
 			-- Check if the mob's target is another assigned tank (not ourselves)
 			if frame.unit and UnitExists(frame.unit.."target") then
 				local targetName = UnitName(frame.unit.."target")

--- a/ElvUI/Modules/Nameplates/Elements/HealthBar.lua
+++ b/ElvUI/Modules/Nameplates/Elements/HealthBar.lua
@@ -35,10 +35,13 @@ function NP:Update_HealthColor(frame)
 		local isTank = E.Role == "Tank" or (E.GetAssignedTankRole and E:GetAssignedTankRole("player"))
 		
 		-- Check if another tank has this mob (for off-tank coloring)
-		-- Only relevant when in a group
+		-- Only relevant when in a group and mob is alive
 		local otherTankHasAggro = false
 		local inGroup = GetNumPartyMembers() > 0 or GetNumRaidMembers() > 0
-		if inGroup and isTank and status and status < 3 then -- We're a tank but don't have aggro
+		local mobHealth = frame.oldHealthBar and frame.oldHealthBar:GetValue() or 0
+		local mobIsAlive = mobHealth > 0 and (not UnitIsDead(frame.unit or ""))
+		
+		if inGroup and mobIsAlive and isTank and status and status < 3 then -- We're a tank but don't have aggro
 			-- Check if the mob's target is another assigned tank (not ourselves)
 			if frame.unit and UnitExists(frame.unit.."target") then
 				local targetName = UnitName(frame.unit.."target")

--- a/ElvUI/Modules/Nameplates/Elements/HealthBar.lua
+++ b/ElvUI/Modules/Nameplates/Elements/HealthBar.lua
@@ -36,14 +36,16 @@ function NP:Update_HealthColor(frame)
 		
 		-- Check if another tank has this mob (for off-tank coloring)
 		local otherTankHasAggro = false
-		if isTank and status and status < 3 then -- We're a tank but don't have aggro (might have some threat from cleave)
-			-- Simple check: if we're targeting this nameplate and its target is a friendly unit
-			-- Check if that friendly unit is another assigned tank
+		if isTank and status and status < 3 then -- We're a tank but don't have aggro
+			-- Check if the mob's target is another assigned tank (not ourselves)
 			if frame.unit and UnitExists(frame.unit.."target") then
 				local targetName = UnitName(frame.unit.."target")
-				if targetName and E.db.general.tankAssignments and E.db.general.tankAssignments[targetName] then
-					-- The mob is targeting another assigned tank
-					otherTankHasAggro = true
+				-- Only color purple if target is another tank (not self) and is a player
+				if targetName and targetName ~= E.myname and UnitIsPlayer(frame.unit.."target") then
+					if E.db.general.tankAssignments and E.db.general.tankAssignments[targetName] then
+						-- The mob is targeting another assigned tank
+						otherTankHasAggro = true
+					end
 				end
 			end
 		end

--- a/ElvUI/Modules/Nameplates/Nameplates.lua
+++ b/ElvUI/Modules/Nameplates/Nameplates.lua
@@ -281,10 +281,17 @@ end
 
 function NP:UnitLevel(frame)
 	local level, boss = frame.oldLevel:GetObjectType() == "FontString" and tonumber(frame.oldLevel:GetText()) or false, frame.BossIcon:IsShown()
+	local elite = frame.EliteIcon and frame.EliteIcon:IsShown()
+	
 	if boss or not level then
 		return "??", 0.9, 0, 0
 	else
-		return level, frame.oldLevel:GetTextColor()
+		-- Add + symbol for elite mobs (matching tooltip behavior)
+		local levelText = tostring(level)
+		if elite then
+			levelText = levelText .. "+"
+		end
+		return levelText, frame.oldLevel:GetTextColor()
 	end
 end
 

--- a/ElvUI/Modules/UnitFrames/Groups/Arena.lua
+++ b/ElvUI/Modules/UnitFrames/Groups/Arena.lua
@@ -149,4 +149,6 @@ function UF:Update_ArenaFrames(frame, db)
 	frame:UpdateAllElements("ForceUpdate")
 end
 
-UF.unitgroupstoload.arena = {5}
+if UF.unitgroupstoload then
+	UF.unitgroupstoload.arena = {5}
+end

--- a/ElvUI/Modules/UnitFrames/Groups/Assist.lua
+++ b/ElvUI/Modules/UnitFrames/Groups/Assist.lua
@@ -186,4 +186,6 @@ function UF:Update_AssistFrames(frame, db)
 	frame:UpdateAllElements("ForceUpdate")
 end
 
-UF.headerstoload.assist = {"MAINASSIST", "ELVUI_UNITTARGET"}
+if UF.headerstoload then
+	UF.headerstoload.assist = {"MAINASSIST", "ELVUI_UNITTARGET"}
+end

--- a/ElvUI/Modules/UnitFrames/Groups/Boss.lua
+++ b/ElvUI/Modules/UnitFrames/Groups/Boss.lua
@@ -149,4 +149,6 @@ function UF:Update_BossFrames(frame, db)
 	frame:UpdateAllElements("ForceUpdate")
 end
 
-UF.unitgroupstoload.boss = {MAX_BOSS_FRAMES}
+if UF.unitgroupstoload then
+	UF.unitgroupstoload.boss = {MAX_BOSS_FRAMES}
+end

--- a/ElvUI/Modules/UnitFrames/Groups/Party.lua
+++ b/ElvUI/Modules/UnitFrames/Groups/Party.lua
@@ -287,4 +287,6 @@ function UF:Update_PartyFrames(frame, db)
 	frame:UpdateAllElements("ForceUpdate")
 end
 
-UF.headerstoload.party = {nil, "ELVUI_UNITPET, ELVUI_UNITTARGET"}
+if UF.headerstoload then
+	UF.headerstoload.party = {nil, "ELVUI_UNITPET, ELVUI_UNITTARGET"}
+end

--- a/ElvUI/Modules/UnitFrames/Groups/Raid.lua
+++ b/ElvUI/Modules/UnitFrames/Groups/Raid.lua
@@ -244,4 +244,6 @@ function UF:Update_RaidFrames(frame, db)
 	frame:UpdateAllElements("ForceUpdate")
 end
 
-UF.headerstoload.raid = true
+if UF.headerstoload then
+	UF.headerstoload.raid = true
+end

--- a/ElvUI/Modules/UnitFrames/Groups/Raid40.lua
+++ b/ElvUI/Modules/UnitFrames/Groups/Raid40.lua
@@ -244,4 +244,6 @@ function UF:Update_Raid40Frames(frame, db)
 	frame:UpdateAllElements("ForceUpdate")
 end
 
-UF.headerstoload.raid40 = true
+if UF.headerstoload then
+	UF.headerstoload.raid40 = true
+end

--- a/ElvUI/Modules/UnitFrames/Groups/RaidPets.lua
+++ b/ElvUI/Modules/UnitFrames/Groups/RaidPets.lua
@@ -186,4 +186,6 @@ function UF:Update_RaidpetFrames(frame, db)
 end
 
 --Added an additional argument at the end, specifying the header Template we want to use
-UF.headerstoload.raidpet = {nil, nil, "SecureGroupPetHeaderTemplate"}
+if UF.headerstoload then
+	UF.headerstoload.raidpet = {nil, nil, "SecureGroupPetHeaderTemplate"}
+end

--- a/ElvUI/Modules/UnitFrames/Groups/Tank.lua
+++ b/ElvUI/Modules/UnitFrames/Groups/Tank.lua
@@ -186,4 +186,6 @@ function UF:Update_TankFrames(frame, db)
 	frame:UpdateAllElements("ForceUpdate")
 end
 
-UF.headerstoload.tank = {"MAINTANK", "ELVUI_UNITTARGET"}
+if UF.headerstoload then
+	UF.headerstoload.tank = {"MAINTANK", "ELVUI_UNITTARGET"}
+end

--- a/ElvUI/Modules/UnitFrames/Units/Focus.lua
+++ b/ElvUI/Modules/UnitFrames/Units/Focus.lua
@@ -136,4 +136,6 @@ function UF:Update_FocusFrame(frame, db)
 	frame:UpdateAllElements("ForceUpdate")
 end
 
-tinsert(UF.unitstoload, "focus")
+if UF.unitstoload then
+	tinsert(UF.unitstoload, "focus")
+end

--- a/ElvUI/Modules/UnitFrames/Units/FocusTarget.lua
+++ b/ElvUI/Modules/UnitFrames/Units/FocusTarget.lua
@@ -106,4 +106,6 @@ function UF:Update_FocusTargetFrame(frame, db)
 	frame:UpdateAllElements("ForceUpdate")
 end
 
-tinsert(UF.unitstoload, "focustarget")
+if UF.unitstoload then
+	tinsert(UF.unitstoload, "focustarget")
+end

--- a/ElvUI/Modules/UnitFrames/Units/Pet.lua
+++ b/ElvUI/Modules/UnitFrames/Units/Pet.lua
@@ -128,4 +128,6 @@ function UF:Update_PetFrame(frame, db)
 	frame:UpdateAllElements("ForceUpdate")
 end
 
-tinsert(UF.unitstoload, "pet")
+if UF.unitstoload then
+	tinsert(UF.unitstoload, "pet")
+end

--- a/ElvUI/Modules/UnitFrames/Units/PetTarget.lua
+++ b/ElvUI/Modules/UnitFrames/Units/PetTarget.lua
@@ -101,4 +101,6 @@ function UF:Update_PetTargetFrame(frame, db)
 	frame:UpdateAllElements("ForceUpdate")
 end
 
-tinsert(UF.unitstoload, "pettarget")
+if UF.unitstoload then
+	tinsert(UF.unitstoload, "pettarget")
+end

--- a/ElvUI/Modules/UnitFrames/Units/Player.lua
+++ b/ElvUI/Modules/UnitFrames/Units/Player.lua
@@ -194,7 +194,9 @@ function UF:Update_PlayerFrame(frame, db)
 	frame:UpdateAllElements("ForceUpdate")
 end
 
-tinsert(UF.unitstoload, "player")
+if UF.unitstoload then
+	tinsert(UF.unitstoload, "player")
+end
 
 local function UpdateClassBar()
 	local frame = _G.ElvUF_Player

--- a/ElvUI/Modules/UnitFrames/Units/Target.lua
+++ b/ElvUI/Modules/UnitFrames/Units/Target.lua
@@ -160,4 +160,6 @@ function UF:Update_TargetFrame(frame, db)
 	frame:UpdateAllElements("ForceUpdate")
 end
 
-tinsert(UF.unitstoload, "target")
+if UF.unitstoload then
+	tinsert(UF.unitstoload, "target")
+end

--- a/ElvUI/Modules/UnitFrames/Units/TargetTarget.lua
+++ b/ElvUI/Modules/UnitFrames/Units/TargetTarget.lua
@@ -106,4 +106,6 @@ function UF:Update_TargetTargetFrame(frame, db)
 	frame:UpdateAllElements("ForceUpdate")
 end
 
-tinsert(UF.unitstoload, "targettarget")
+if UF.unitstoload then
+	tinsert(UF.unitstoload, "targettarget")
+end

--- a/ElvUI/Modules/UnitFrames/Units/TargetTargetTarget.lua
+++ b/ElvUI/Modules/UnitFrames/Units/TargetTargetTarget.lua
@@ -103,4 +103,6 @@ function UF:Update_TargetTargetTargetFrame(frame, db)
 	frame:UpdateAllElements("ForceUpdate")
 end
 
-tinsert(UF.unitstoload, "targettargettarget")
+if UF.unitstoload then
+	tinsert(UF.unitstoload, "targettargettarget")
+end


### PR DESCRIPTION
## Tank Role Management System
- Add manual tank role assignment via right-click menu
- Store tank assignments in saved variables (local only)
- Add /tankmode command to toggle tank role
- Tank role assignments persist across sessions
- Simple manual toggle - no automatic detection

## Threat Color System Enhancements (Fixes #9)
- Fix inverted threat colors for tanks vs DPS
- Tanks: Green = tanking (good), Red = no threat (bad)
- DPS: Green = no threat (good), Red = high threat (bad)
- Add purple color for off-tank threat situations
- Only show threat colors during combat

## Nameplate Threat Coloring
- Dynamically color nameplates based on threat status
- Support for coordinated tanking with off-tank colors
- Automatic scaling based on threat level

## API Compatibility Fixes
- Replace IsInRaid with GetNumRaidMembers for 3.3.5a
- Fix nil reference errors in unit frame loading
- Add proper nil checks throughout codebase