### PR TITLE
FEAT: Add elite + symbol to nameplate levels

### DIFF
--- a/ElvUI/Modules/Nameplates/Nameplates.lua
+++ b/ElvUI/Modules/Nameplates/Nameplates.lua
@@ -281,10 +281,17 @@ end
 
 function NP:UnitLevel(frame)
 	local level, boss = frame.oldLevel:GetObjectType() == "FontString" and tonumber(frame.oldLevel:GetText()) or false, frame.BossIcon:IsShown()
+	local elite = frame.EliteIcon and frame.EliteIcon:IsShown()
+	
 	if boss or not level then
 		return "??", 0.9, 0, 0
 	else
-		return level, frame.oldLevel:GetTextColor()
+		-- Add + symbol for elite mobs (matching tooltip behavior)
+		local levelText = tostring(level)
+		if elite then
+			levelText = levelText .. "+"
+		end
+		return levelText, frame.oldLevel:GetTextColor()
 	end
 end
 


### PR DESCRIPTION
Elite mobs now display + after their level in nameplates (e.g., "60+") to match the tooltip behavior where elite mobs show the + symbol.

- Check if EliteIcon is shown to determine elite status
- Append + to level text for elite mobs
- Works for all nameplate types