### PR TITLE
new features: execute threshold on nameplates / hide backdrop on actionbars / HoT indicator on player frame

### DIFF
--- a/ElvUI/Modules/ActionBars/ActionBars.lua
+++ b/ElvUI/Modules/ActionBars/ActionBars.lua
@@ -555,13 +555,20 @@ function AB:StyleButton(button, noBackdrop, useMasque)
 	end
 
 	if not button.noBackdrop and not button.backdrop and not button.useMasque then
-		button:CreateBackdrop(self.db.transparentButtons and "Transparent", true)
-		button.backdrop:SetAllPoints()
+		if not self.db.hideButtonBackdrops then
+			button:CreateBackdrop(self.db.transparentButtons and "Transparent", true)
+			button.backdrop:SetAllPoints()
+		end
 	end
 
 	if icon then
-		icon:SetTexCoord(unpack(E.TexCoords))
-		icon:SetInside()
+		if self.db.hideButtonBackdrops then
+			icon:SetTexCoord(0, 1, 0, 1) -- Revert to default rounded WoW icon
+			icon:SetAllPoints()
+		else
+			icon:SetTexCoord(unpack(E.TexCoords))
+			icon:SetInside()
+		end
 	end
 
 	if self.db.hotkeytext or self.db.useRangeColorText then

--- a/ElvUI/Modules/Nameplates/Elements/HealthBar.lua
+++ b/ElvUI/Modules/Nameplates/Elements/HealthBar.lua
@@ -152,6 +152,34 @@ function NP:Update_Health(frame)
 	end
 end
 
+function NP:Update_ExecuteThreshold(frame)
+	if not frame or not frame.UnitType or not frame.Health then return end
+
+	local indicator = frame.Health.ExecuteThreshold
+	if not indicator then return end
+
+	local db = self.db.executeIndicator
+	local enabled = db and db.enable
+	local showForUnit = frame.UnitType == "ENEMY_NPC" or frame.UnitType == "ENEMY_PLAYER"
+
+	if enabled and showForUnit and frame.Health:IsShown() then
+		local threshold = db.threshold or 0.2
+		local width = frame.Health:GetWidth()
+		local lineWidth = (E.mult and E.mult > 0) and E.mult or 1
+		local offset = width * threshold
+		local color = db.color or {r = 1, g = 0.2, b = 0.2, a = 0.9}
+
+		indicator:ClearAllPoints()
+		indicator:SetPoint("TOP", frame.Health, "TOPLEFT", offset, 0)
+		indicator:SetPoint("BOTTOM", frame.Health, "BOTTOMLEFT", offset, 0)
+		indicator:SetWidth(lineWidth)
+		indicator:SetVertexColor(color.r, color.g, color.b, color.a or 1)
+		indicator:Show()
+	else
+		indicator:Hide()
+	end
+end
+
 function NP:RegisterHealthBarCallbacks(frame, valueChangeCB, colorChangeCB)
 	if valueChangeCB then
 		frame.HealthValueChangeCallbacks = frame.HealthValueChangeCallbacks or {}
@@ -170,6 +198,8 @@ function NP:Update_HealthBar(frame)
 	else
 		frame.Health:Hide()
 	end
+
+	self:Update_ExecuteThreshold(frame)
 end
 
 function NP:Configure_HealthBarScale(frame, scale, noPlayAnimation)
@@ -209,12 +239,15 @@ function NP:Configure_HealthBar(frame, configuring)
 			healthBar.Text:Hide()
 		end
 	end
+
+	self:Update_ExecuteThreshold(frame)
 end
 
 local function HealthBar_OnSizeChanged(self, width)
 	local health = self:GetValue()
 	local _, maxHealth = self:GetMinMaxValues()
 	self:GetStatusBarTexture():SetPoint("TOPRIGHT", -(width * ((maxHealth - health) / maxHealth)), 0)
+	NP:Update_ExecuteThreshold(self:GetParent())
 end
 
 function NP:Construct_HealthBar(parent)
@@ -229,6 +262,10 @@ function NP:Construct_HealthBar(parent)
 	parent.FlashTexture:Point("BOTTOMLEFT", frame:GetStatusBarTexture(), "BOTTOMLEFT")
 	parent.FlashTexture:Point("TOPRIGHT", frame:GetStatusBarTexture(), "TOPRIGHT")
 	parent.FlashTexture:Hide()
+
+	frame.ExecuteThreshold = frame:CreateTexture(nil, "OVERLAY")
+	frame.ExecuteThreshold:SetTexture(LSM:Fetch("background", "ElvUI Blank"))
+	frame.ExecuteThreshold:Hide()
 
 	frame.Text = frame:CreateFontString(nil, "OVERLAY")
 	frame.Text:SetAllPoints(frame)

--- a/ElvUI/Modules/UnitFrames/Units/Player.lua
+++ b/ElvUI/Modules/UnitFrames/Units/Player.lua
@@ -25,6 +25,7 @@ function UF:Construct_PlayerFrame(frame)
 	frame.Portrait2D = self:Construct_Portrait(frame, "texture")
 	frame.Buffs = self:Construct_Buffs(frame)
 	frame.Debuffs = self:Construct_Debuffs(frame)
+	frame.AuraWatch = self:Construct_AuraWatch(frame)
 	frame.Castbar = self:Construct_Castbar(frame, L["Player Castbar"])
 
 	--Create a holder frame all "classbars" can be positioned into
@@ -189,6 +190,9 @@ function UF:Update_PlayerFrame(frame, db)
 
 	--CustomTexts
 	UF:Configure_CustomTexts(frame)
+
+	--BuffIndicator
+	UF:UpdateAuraWatch(frame)
 
 	E:SetMoverSnapOffset(frame:GetName().."Mover", -(12 + db.castbar.height))
 	frame:UpdateAllElements("ForceUpdate")

--- a/ElvUI/Settings/Profile.lua
+++ b/ElvUI/Settings/Profile.lua
@@ -4155,6 +4155,7 @@ P.actionbar = {
 	movementModifier = "SHIFT",
 	transparentBackdrops = false,
 	transparentButtons = false,
+	hideButtonBackdrops = false,
 	globalFadeAlpha = 0,
 	lockActionBars = true,
 	rightClickSelfCast = false,

--- a/ElvUI/Settings/Profile.lua
+++ b/ElvUI/Settings/Profile.lua
@@ -303,6 +303,11 @@ P.nameplates = {
 	motionType = "OVERLAP",
 
 	lowHealthThreshold = 0.4,
+	executeIndicator = {
+		enable = false,
+		threshold = 0.2,
+		color = {r = 1, g = 0.2, b = 0.2, a = 0.9}
+	},
 
 	showFriendlyCombat = "DISABLED",
 	showEnemyCombat = "DISABLED",

--- a/ElvUI/Settings/Profile.lua
+++ b/ElvUI/Settings/Profile.lua
@@ -1390,6 +1390,12 @@ P.unitframe = {
 			width = 270,
 			height = 54,
 			lowmana = 30,
+                        buffIndicator = {
+                                enable = true,
+                                size = 8,
+                                fontSize = 10,
+                                profileSpecific = false
+                        },
 			healPrediction = {
 				enable = true
 			},

--- a/ElvUI_OptionsUI/ActionBars.lua
+++ b/ElvUI_OptionsUI/ActionBars.lua
@@ -76,6 +76,7 @@ local function BuildABConfig()
 				order = 7,
 				type = "toggle",
 				name = L["RightClick Self-Cast"],
+				desc = L["Allows you to self-cast spells by right-clicking them on the action bar."],
 				set = function(info, value)
 					E.db.actionbar.rightClickSelfCast = value
 					for _, bar in pairs(AB.handledBars) do
@@ -108,6 +109,7 @@ local function BuildABConfig()
 				order = 10,
 				type = "toggle",
 				name = L["Desaturate Cooldowns"],
+				desc = L["Turns the action button icon grayscale while the ability is on cooldown."],
 				set = function(info, value)
 					E.db.actionbar.desaturateOnCooldown = value
 					AB:ToggleDesaturation(value)
@@ -117,6 +119,7 @@ local function BuildABConfig()
 				order = 11,
 				type = "toggle",
 				name = L["Transparent Backdrops"],
+				desc = L["Makes the action bar backgrounds transparent (Requires a UI reload)."],
 				set = function(info, value)
 					E.db.actionbar.transparentBackdrops = value
 					E:StaticPopup_Show("CONFIG_RL")
@@ -126,6 +129,7 @@ local function BuildABConfig()
 				order = 12,
 				type = "toggle",
 				name = L["Transparent Buttons"],
+				desc = L["Makes the action buttons themselves transparent (Requires a UI reload)."],
 				set = function(info, value)
 					E.db.actionbar.transparentButtons = value
 					E:StaticPopup_Show("CONFIG_RL")

--- a/ElvUI_OptionsUI/ActionBars.lua
+++ b/ElvUI_OptionsUI/ActionBars.lua
@@ -135,6 +135,16 @@ local function BuildABConfig()
 					E:StaticPopup_Show("CONFIG_RL")
 				end
 			},
+			hideButtonBackdrops = {
+				order = 12.5,
+				type = "toggle",
+				name = L["Hide Button Backdrops"],
+				desc = L["Hides the ElvUI black backdrop on action buttons and uses the default WoW icons without cropping."],
+				set = function(info, value)
+					E.db.actionbar.hideButtonBackdrops = value
+					E:StaticPopup_Show("CONFIG_RL")
+				end
+			},
 			movementModifier = {
 				order = 13,
 				type = "select",

--- a/ElvUI_OptionsUI/Filters.lua
+++ b/ElvUI_OptionsUI/Filters.lua
@@ -661,6 +661,7 @@ local function UpdateFilterGroup()
 							UF:UpdateAuraWatchFromHeader("raid")
 							UF:UpdateAuraWatchFromHeader("raid40")
 							UF:UpdateAuraWatchFromHeader("party")
+							if _G.ElvUF_Player then UF:UpdateAuraWatch(_G.ElvUF_Player) end
 							UF:UpdateAuraWatchFromHeader("raidpet", true)
 						end
 					end
@@ -683,6 +684,7 @@ local function UpdateFilterGroup()
 						UF:UpdateAuraWatchFromHeader("raid")
 						UF:UpdateAuraWatchFromHeader("raid40")
 						UF:UpdateAuraWatchFromHeader("party")
+						if _G.ElvUF_Player then UF:UpdateAuraWatch(_G.ElvUF_Player) end
 						UF:UpdateAuraWatchFromHeader("raidpet", true)
 					end,
 					disabled = function() return not selectedSpell end
@@ -767,6 +769,7 @@ local function UpdateFilterGroup()
 					UF:UpdateAuraWatchFromHeader("raid")
 					UF:UpdateAuraWatchFromHeader("raid40")
 					UF:UpdateAuraWatchFromHeader("party")
+					if _G.ElvUF_Player then UF:UpdateAuraWatch(_G.ElvUF_Player) end
 					UF:UpdateAuraWatchFromHeader("raidpet", true)
 				end,
 				args = {
@@ -832,6 +835,7 @@ local function UpdateFilterGroup()
 							UF:UpdateAuraWatchFromHeader("raid")
 							UF:UpdateAuraWatchFromHeader("raid40")
 							UF:UpdateAuraWatchFromHeader("party")
+							if _G.ElvUF_Player then UF:UpdateAuraWatch(_G.ElvUF_Player) end
 							UF:UpdateAuraWatchFromHeader("raidpet", true)
 						end
 					},
@@ -859,6 +863,7 @@ local function UpdateFilterGroup()
 							UF:UpdateAuraWatchFromHeader("raid")
 							UF:UpdateAuraWatchFromHeader("raid40")
 							UF:UpdateAuraWatchFromHeader("party")
+							if _G.ElvUF_Player then UF:UpdateAuraWatch(_G.ElvUF_Player) end
 							UF:UpdateAuraWatchFromHeader("raidpet", true)
 						end
 					},
@@ -916,6 +921,7 @@ local function UpdateFilterGroup()
 							UF:UpdateAuraWatchFromHeader("raid")
 							UF:UpdateAuraWatchFromHeader("raid40")
 							UF:UpdateAuraWatchFromHeader("party")
+							if _G.ElvUF_Player then UF:UpdateAuraWatch(_G.ElvUF_Player) end
 						end
 					end
 				},
@@ -937,6 +943,7 @@ local function UpdateFilterGroup()
 						UF:UpdateAuraWatchFromHeader("raid")
 						UF:UpdateAuraWatchFromHeader("raid40")
 						UF:UpdateAuraWatchFromHeader("party")
+						if _G.ElvUF_Player then UF:UpdateAuraWatch(_G.ElvUF_Player) end
 					end,
 					disabled = function() return not selectedSpell end
 				},
@@ -1025,6 +1032,7 @@ local function UpdateFilterGroup()
 					UF:UpdateAuraWatchFromHeader("raid")
 					UF:UpdateAuraWatchFromHeader("raid40")
 					UF:UpdateAuraWatchFromHeader("party")
+					if _G.ElvUF_Player then UF:UpdateAuraWatch(_G.ElvUF_Player) end
 				end,
 				args = {
 					enabled = {
@@ -1091,6 +1099,7 @@ local function UpdateFilterGroup()
 							UF:UpdateAuraWatchFromHeader("raid")
 							UF:UpdateAuraWatchFromHeader("raid40")
 							UF:UpdateAuraWatchFromHeader("party")
+							if _G.ElvUF_Player then UF:UpdateAuraWatch(_G.ElvUF_Player) end
 						end
 					},
 					displayText = {
@@ -1118,6 +1127,7 @@ local function UpdateFilterGroup()
 							UF:UpdateAuraWatchFromHeader("raid")
 							UF:UpdateAuraWatchFromHeader("raid40")
 							UF:UpdateAuraWatchFromHeader("party")
+							if _G.ElvUF_Player then UF:UpdateAuraWatch(_G.ElvUF_Player) end
 						end
 					},
 					decimalThreshold = {

--- a/ElvUI_OptionsUI/Nameplates.lua
+++ b/ElvUI_OptionsUI/Nameplates.lua
@@ -3579,8 +3579,19 @@ E.Options.args.nameplate = {
 							isPercent = true,
 							min = 0, max = 1, step = 0.01
 						},
-						showEnemyCombat = {
+						executeIndicator = {
 							order = 5,
+							type = "toggle",
+							name = L["Execute Threshold"],
+							desc = L["Show a 20% execute marker on enemy nameplate health bars."],
+							get = function() return E.db.nameplates.executeIndicator.enable end,
+							set = function(info, value)
+								E.db.nameplates.executeIndicator.enable = value
+								NP:ConfigureAll()
+							end
+						},
+						showEnemyCombat = {
+							order = 6,
 							type = "select",
 							name = L["Enemy Combat Toggle"],
 							desc = L["Control enemy nameplates toggling on or off when in combat."],
@@ -3595,7 +3606,7 @@ E.Options.args.nameplate = {
 							end
 						},
 						showFriendlyCombat = {
-							order = 6,
+							order = 7,
 							type = "select",
 							name = L["Friendly Combat Toggle"],
 							desc = L["Control friendly nameplates toggling on or off when in combat."],
@@ -3610,7 +3621,7 @@ E.Options.args.nameplate = {
 							end
 						},
 						resetFilters = {
-							order = 7,
+							order = 8,
 							type = "execute",
 							name = L["Reset Aura Filters"],
 							func = function(info, value)
@@ -3618,12 +3629,12 @@ E.Options.args.nameplate = {
 							end
 						},
 						fadeIn = {
-							order = 8,
+							order = 9,
 							type = "toggle",
 							name = L["Alpha Fading"]
 						},
 						smoothbars = {
-							order = 9,
+							order = 10,
 							type = "toggle",
 							name = L["Smooth Bars"],
 							desc = L["Bars will transition smoothly."],
@@ -3633,12 +3644,12 @@ E.Options.args.nameplate = {
 							end
 						},
 						highlight = {
-							order = 10,
+							order = 11,
 							type = "toggle",
 							name = L["Hover Highlight"]
 						},
 						nameColoredGlow = {
-							order = 11,
+							order = 12,
 							type = "toggle",
 							name = L["Name Colored Glow"],
 							desc = L["Use the Name Color of the unit for the Name Glow."],

--- a/ElvUI_OptionsUI/UnitFrames.lua
+++ b/ElvUI_OptionsUI/UnitFrames.lua
@@ -3666,6 +3666,51 @@ E.Options.args.unitframe.args.player = {
 			name = L["Restore Defaults"],
 			func = function(info) E:StaticPopup_Show("RESET_UF_UNIT", L["Player"], nil, {unit="player", mover="Player Frame"}) end
 		},
+		buffIndicator = {
+			order = 600,
+			type = "group",
+			name = L["Buff Indicator"],
+			get = function(info) return E.db.unitframe.units.player.buffIndicator[info[#info]] end,
+			set = function(info, value) E.db.unitframe.units.player.buffIndicator[info[#info]] = value UF:CreateAndUpdateUF("player") end,
+			args = {
+				enable = {
+					type = "toggle",
+					name = L["Enable"],
+					order = 1
+				},
+				size = {
+					type = "range",
+					name = L["Size"],
+					desc = L["Size of the indicator icon."],
+					order = 2,
+					min = 4, max = 50, step = 1
+				},
+				fontSize = {
+					type = "range",
+					name = L["FONT_SIZE"],
+					order = 3,
+					min = 7, max = 22, step = 1
+				},
+				profileSpecific = {
+					type = "toggle",
+					name = L["Profile Specific"],
+					desc = L["Use the profile specific filter 'Buff Indicator (Profile)' instead of the global filter 'Buff Indicator'."],
+					order = 4
+				},
+				configureButton = {
+					type = "execute",
+					name = L["Configure Auras"],
+					func = function()
+						if E.db.unitframe.units.player.buffIndicator.profileSpecific then
+							E:SetToFilterConfig("Buff Indicator (Profile)")
+						else
+							E:SetToFilterConfig("Buff Indicator")
+						end
+					end,
+					order = 5
+				}
+			}
+		},
 		copyFrom = {
 			order = 4,
 			type = "select",


### PR DESCRIPTION
i added some features to the addon:

## you can toggle an execute threshold on enemy nameplates
<img width="963" height="477" alt="grafik" src="https://github.com/user-attachments/assets/6937d983-d0a8-4c54-8a41-e6c97d48f7b1" />
<img width="275" height="122" alt="grafik" src="https://github.com/user-attachments/assets/95ef33d2-68ed-4f14-b584-8828458854e4" />


## you can toggle if the action bars should actually have a backdrop or if they should just be an invisible grid
#### also added some tooltips to the actionbar options 
<img width="874" height="273" alt="grafik" src="https://github.com/user-attachments/assets/7ccdb580-1429-420a-bb37-7d8ffb32b45c" />

<img width="1285" height="235" alt="grafik" src="https://github.com/user-attachments/assets/1e8b1b25-aa57-44b3-886b-478d2a14e3a2" />

## added the same HoT indicator that are shown on friendly units in party and raid frames to the player frame
<img width="982" height="429" alt="grafik" src="https://github.com/user-attachments/assets/ec6f24b1-8a28-4f64-8089-690edea1ce03" />

<img width="335" height="149" alt="grafik" src="https://github.com/user-attachments/assets/0ba26cf5-235f-4616-a638-4f2405106c5b" />
 
