### PR TITLE
fix: guard health color updates when unit is missing during profile/s…

### DIFF
--- a/ElvUI/Modules/UnitFrames/Elements/Health.lua
+++ b/ElvUI/Modules/UnitFrames/Elements/Health.lua
@@ -231,10 +231,11 @@ end
 function UF:PostUpdateHealthColor(unit, r, g, b)
 	local parent = self:GetParent()
 	local colors = E.db.unitframe.colors
+	unit = unit or self.unit or parent.unit
 
 	local newr, newg, newb -- fallback for bg if custom settings arent used
 	if not b then r, g, b = colors.health.r, colors.health.g, colors.health.b end
-	if (((colors.healthclass and colors.colorhealthbyvalue) or (colors.colorhealthbyvalue and parent.isForced)) and not (UnitIsTapped(unit) and not UnitIsTappedByPlayer(unit))) then
+	if (((colors.healthclass and colors.colorhealthbyvalue) or (colors.colorhealthbyvalue and parent.isForced)) and not (unit and UnitIsTapped(unit) and not UnitIsTappedByPlayer(unit))) then
 		local cur, max = self.cur or 1, self.max or 100
 		if parent.isForced then
 			cur = parent.forcedHealth or cur
@@ -248,14 +249,14 @@ function UF:PostUpdateHealthColor(unit, r, g, b)
 	if self.bg then
 		self.bg.multiplier = (colors.healthMultiplier > 0 and colors.healthMultiplier) or 0.35
 
-		if colors.useDeadBackdrop and UnitIsDeadOrGhost(unit) then
+		if colors.useDeadBackdrop and unit and UnitIsDeadOrGhost(unit) then
 			self.bg:SetVertexColor(colors.health_backdrop_dead.r, colors.health_backdrop_dead.g, colors.health_backdrop_dead.b)
 		elseif colors.customhealthbackdrop then
 			self.bg:SetVertexColor(colors.health_backdrop.r, colors.health_backdrop.g, colors.health_backdrop.b)
 		elseif colors.classbackdrop then
-			local reaction, color = (UnitReaction(unit, "player"))
+			local reaction, color = (unit and UnitReaction(unit, "player"))
 
-			if UnitIsPlayer(unit) then
+			if unit and UnitIsPlayer(unit) then
 				local _, Class = UnitClass(unit)
 				color = parent.colors.class[Class]
 			elseif reaction then


### PR DESCRIPTION
this fixes an error when changing specs with the "cutaway bars" option enabled:

```
Message: ...\AddOns\ElvUI\Modules\UnitFrames\Elements\Health.lua:237: Usage: UnitIsTapped("unit")
Time: 05/21/26 23:37:15
Count: 2
Stack: (tail call): ?
[C]: ?
...\AddOns\ElvUI\Modules\UnitFrames\Elements\Health.lua:237: in function <...\AddOns\ElvUI\Modules\UnitFrames\Elements\Health.lua:231>
[C]: in function `PostUpdateColor'
...AddOns\ElvUI\Modules\UnitFrames\Elements\Cutaway.lua:69: in function `Configure_Cutaway'
...ace\AddOns\ElvUI\Modules\UnitFrames\Groups\Party.lua:285: in function `?'
...rface\AddOns\ElvUI\Modules\UnitFrames\UnitFrames.lua:736: in function `Update'
...rface\AddOns\ElvUI\Modules\UnitFrames\UnitFrames.lua:693: in function `Update'
...rface\AddOns\ElvUI\Modules\UnitFrames\UnitFrames.lua:1016: in function `UpdateAllHeaders'
...rface\AddOns\ElvUI\Modules\UnitFrames\UnitFrames.lua:496: in function `Update_AllFrames'
Interface\AddOns\ElvUI\Core\Core.lua:927: in function `?'
...1.0\Libs\CallbackHandler-1.0\CallbackHandler-1.0.lua:145: in function <...1.0\Libs\CallbackHandler-1.0\CallbackHandler-1.0.lua:145>
[string "safecall Dispatcher[3]"]:4: in function <[string "safecall Dispatcher[3]"]:4>
[C]: ?
[string "safecall Dispatcher[3]"]:13: in function `?'
...1.0\Libs\CallbackHandler-1.0\CallbackHandler-1.0.lua:90: in function `Fire'
...\AddOns\ElvUI\Libraries\Ace3\AceDB-3.0\AceDB-3.0.lua:463: in function `SetProfile'
Interface\AddOns\Critline\libs\LibDualSpec-1.0.lua:169: in function `CheckDualSpecState'
Interface\AddOns\Critline\libs\LibDualSpec-1.0.lua:308: in function <Interface\AddOns\Critline\libs\LibDualSpec-1.0.lua:303>

Locals: No locals to dump
```
Added safe guards in health color update logic for cases where no valid unit token is available yet.
Prevented UnitIsTapped and related unit-based checks from running with nil input.
